### PR TITLE
Unnecessary body bottom margin

### DIFF
--- a/style.css
+++ b/style.css
@@ -64,7 +64,7 @@ body
 {
 	font-family : Linux Libertine O, Liberation Serif, Times New Roman;
 	text-align : justify;
-	margin : 0% 20% 5% 20%;
+	margin : 0% 20% 0% 20%;
 }
 
 h2


### PR DESCRIPTION
`body{ margin-bottom: 5% }` was causing the page to overflow vertically, enforcing the presence of a scrollbar despite there being no content further down.